### PR TITLE
Fix legacy cut plane detection

### DIFF
--- a/neuror/cut_plane/detection.py
+++ b/neuror/cut_plane/detection.py
@@ -16,7 +16,7 @@ from scipy.optimize import minimize
 from scipy.special import factorial
 
 from neuror.cut_plane.planes import HalfSpace, PlaneEquation
-from neuror.cut_plane.legacy_detection import cut_detect
+from neuror.cut_plane.legacy_detection import internal_cut_detection
 
 L = logging.getLogger(__name__)
 
@@ -168,7 +168,7 @@ class CutPlane(HalfSpace):
         if not isinstance(neuron, Neuron):
             neuron = load_neuron(neuron)
 
-        cut_leaves, side = cut_detect(neuron, axis)
+        cut_leaves, side = internal_cut_detection(neuron, axis)
 
         plane = cls([int(axis.upper() == 'X'), int(axis.upper() == 'Y'),
                      int(axis.upper() == 'Z'), 0],

--- a/neuror/cut_plane/legacy_detection.py
+++ b/neuror/cut_plane/legacy_detection.py
@@ -5,28 +5,66 @@ https://bbpcode.epfl.ch/source/xref/platform/BlueRepairSDK/BlueRepairSDK/src/rep
 '''
 import logging
 import numpy as np
+from collections import defaultdict
 
+from morph_tool import apical_point_section_segment
 from neurom import iter_sections
 from neurom.core import Tree
 from neurom.core.dataformat import COLS
 
+from neuror.utils import repair_type_map, RepairType
+
 L = logging.getLogger(__name__)
 
 
-def cut_detect(neuron, axis):
+def internal_cut_detection(neuron, axis, offset):
+    '''As in:
+
+    https://bbpcode.epfl.ch/source/xref/platform/BlueRepairSDK/BlueRepairSDK/src/repair.cpp#263
+
+'''
+    axis = {'x': COLS.X, 'y': COLS.Y, 'z': COLS.Z}[axis.lower()]
+
+    side = cut_detect(neuron, axis, 0)
+
+    cut = defaultdict(lambda key: False)
+
+    # reclassify cut points in tuft,based on apical point position
+    apical_section_id, point_id = apical_point_section_segment(neuron)
+    if apical_section_id is not None:
+        apical_section = neuron.sections[apical_section_id]
+        apical_offset = apical_section.points[point_id, axis]
+        cut_mark(apical_section.children, cut, apical_offset, side, axis)
+    else:
+        apical_section = None
+
+    extended_types = repair_type_map(neuron, apical_section)
+    oblique_roots = get_obliques(neuron, extended_types)
+
+    # reclassify points in obliques. based on the position of their root.
+    for root in oblique_roots:
+        offset = root.points[0]
+
+        # z is hard coded in the original code as well
+        cut_mark(root.children, cut, 'z', side, axis)
+
+    cut_leaves = list()
+    for leaf in iter_sections(neuron, iterator_type=Tree.ileaf):
+        coord = leaf.points[-1, COLS.XYZ]
+        if coord[axis] * side > offset:
+            cut_leaves.append(coord)
+
+    return np.array(cut_leaves), side
+
+
+def cut_detect(neuron, axis, offset):
     '''Detect the cut leaves the old way
 
     The cut leaves are simply the leaves that live
     on the half-space (split along the 'axis' coordinate)
     with the biggest number of leaves
     '''
-    # In the original code, offset was a function argument
-    # but it was always used with offset = 0
-    offset = 0
-
     count_plus = count_minus = sum_plus = sum_minus = 0
-
-    axis = {'x': COLS.X, 'y': COLS.Y, 'z': COLS.Z}[axis.lower()]
 
     for leaf in iter_sections(neuron, iterator_type=Tree.ileaf):
         coord = leaf.points[-1, axis]
@@ -45,11 +83,37 @@ def cut_detect(neuron, axis):
     else:
         sign = -1
 
-    cut_leaves = list()
-    for leaf in iter_sections(neuron, iterator_type=Tree.ileaf):
-        coord = leaf.points[-1, COLS.XYZ]
 
-        if coord[axis] * sign > offset:
-            cut_leaves.append(coord)
+    return sign
 
-    return np.array(cut_leaves), sign
+def get_obliques(neuron, repair_type_map):
+    '''https://bbpcode.epfl.ch/source/xref/platform/BlueRepairSDK/BlueRepairSDK/src/helper_dendrite.cpp#212'''
+    return [section for section in iter_sections(neuron)
+            if (repair_type_map[section] == RepairType.oblique and
+                not section.is_root and
+                repair_type_map[section.parent] == RepairType.trunk)]
+
+def cut_mark(sections, cut, offset, side, axis):
+    '''https://bbpcode.epfl.ch/source/xref/platform/BlueRepairSDK/BlueRepairSDK/src/helper_dendrite.cpp#654'''
+    for sec in sections:
+        if sec.children:
+            cut[sec] = False
+            continue
+
+        r = sec.points[-1, axis]
+
+        growing_back = False
+        mysec = sec
+
+        while mysec.parent:
+            for point in mysec.points:
+                mr = point[axis]
+                growing_back |= (mr - (r + (float(side) * 15.0))) * side > 0
+            if growing_back:
+                break
+            mysec = mysec.parent
+
+        cut[sec] = ((r - offset) * side > 0 and \
+                    not growing_back and \
+                    sec.segments().size() > 1)
+    return cut

--- a/neuror/cut_plane/legacy_detection.py
+++ b/neuror/cut_plane/legacy_detection.py
@@ -4,31 +4,28 @@ As implemented in:
 https://bbpcode.epfl.ch/source/xref/platform/BlueRepairSDK/BlueRepairSDK/src/repair.cpp#263
 '''
 import logging
-import numpy as np
 from collections import defaultdict
 
+import numpy as np
 from morph_tool import apical_point_section_segment
 from neurom import iter_sections
 from neurom.core import Tree
 from neurom.core.dataformat import COLS
 
-from neuror.utils import repair_type_map, RepairType
+from neuror.utils import RepairType, repair_type_map
 
 L = logging.getLogger(__name__)
 
 
-def ids(sections):
-    print([sec.id for sec in sections])
-
-
 def children_ids(section):
     '''
-        https://bbpcode.epfl.ch/source/xref/platform/BlueRepairSDK/BlueRepairSDK/src/helper_dendrite.cpp#111
+    https://bbpcode.epfl.ch/source/xref/platform/BlueRepairSDK/BlueRepairSDK/src/helper_dendrite.cpp#111
 
     Except that it returns section instead of ids
 
     '''
     return list(section.ipreorder())
+
 
 def internal_cut_detection(neuron, axis):
     '''As in:
@@ -52,7 +49,6 @@ def internal_cut_detection(neuron, axis):
 
     extended_types = repair_type_map(neuron, apical_section)
     oblique_roots = get_obliques(neuron, extended_types)
-
 
     # reclassify points in obliques. based on the position of their root.
     for root in oblique_roots:
@@ -98,14 +94,20 @@ def cut_detect(neuron, cut, offset, axis):
 
     return sign
 
-def get_obliques(neuron, repair_type_map):
-    '''https://bbpcode.epfl.ch/source/xref/platform/BlueRepairSDK/BlueRepairSDK/src/helper_dendrite.cpp#212'''
+
+def get_obliques(neuron, extended_types):
+    '''
+    https://bbpcode.epfl.ch/source/xref/platform/BlueRepairSDK/BlueRepairSDK/src/helper_dendrite.cpp#212
+    '''
     return [section for section in iter_sections(neuron)
-            if (repair_type_map[section] == RepairType.oblique and
-                repair_type_map[section.parent] == RepairType.trunk)]
+            if (extended_types[section] == RepairType.oblique and
+                extended_types[section.parent] == RepairType.trunk)]
+
 
 def cut_mark(sections, cut, offset, side, axis):
-    '''https://bbpcode.epfl.ch/source/xref/platform/BlueRepairSDK/BlueRepairSDK/src/helper_dendrite.cpp#654'''
+    '''
+    https://bbpcode.epfl.ch/source/xref/platform/BlueRepairSDK/BlueRepairSDK/src/helper_dendrite.cpp#654
+    '''
     for sec in sections:
         if sec.children:
             cut[sec] = False

--- a/neuror/main.py
+++ b/neuror/main.py
@@ -22,7 +22,7 @@ from scipy.spatial.distance import cdist
 
 from neuror import axon
 from neuror.cut_plane import CutPlane
-from neuror.utils import direction, rotation_matrix, section_length, repair_type_map
+from neuror.utils import direction, rotation_matrix, section_length, repair_type_map, RepairType
 
 SEG_LENGTH = 5.0
 SHOLL_LAYER_SIZE = 10

--- a/neuror/main.py
+++ b/neuror/main.py
@@ -406,6 +406,8 @@ class Repair(object):
                      is_branch_intact(neurite.root_node, self.cut_leaves))]
         obliques = self._find_intact_obliques()
 
+        tufts = [section.id for section in iter_sections(self.neuron)
+                 if (self.repair_type_map[section] == RepairType.tuft)]
         tufts = [section for section in iter_sections(self.neuron)
                  if (self.repair_type_map[section] == RepairType.tuft and
                      not is_cut_section(section, self.cut_leaves))]

--- a/neuror/main.py
+++ b/neuror/main.py
@@ -393,8 +393,6 @@ class Repair(object):
                      is_branch_intact(neurite.root_node, self.cut_leaves))]
         obliques = self._find_intact_obliques()
 
-        tufts = [section.id for section in iter_sections(self.neuron)
-                 if self.repair_type_map[section] == RepairType.tuft]
         tufts = [section for section in iter_sections(self.neuron)
                  if (self.repair_type_map[section] == RepairType.tuft and
                      not is_cut_section(section, self.cut_leaves))]

--- a/neuror/main.py
+++ b/neuror/main.py
@@ -394,7 +394,7 @@ class Repair(object):
         obliques = self._find_intact_obliques()
 
         tufts = [section.id for section in iter_sections(self.neuron)
-                 if (self.repair_type_map[section] == RepairType.tuft)]
+                 if self.repair_type_map[section] == RepairType.tuft]
         tufts = [section for section in iter_sections(self.neuron)
                  if (self.repair_type_map[section] == RepairType.tuft and
                      not is_cut_section(section, self.cut_leaves))]

--- a/neuror/utils.py
+++ b/neuror/utils.py
@@ -1,12 +1,48 @@
 '''Utils module'''
 import logging
 import json
+from enum import Enum
 
 import numpy as np
 
-from neurom import NeuriteType
+from neurom import NeuriteType, iter_sections
+from morphio import SectionType
 
 L = logging.getLogger('neuror')
+
+class RepairType(Enum):
+    '''The types used for the repair.
+
+    based on
+    https://bbpcode.epfl.ch/browse/code/platform/BlueRepairSDK/tree/BlueRepairSDK/src/helper_dendrite.h#n22
+    '''
+    trunk = 0
+    tuft = 1
+    oblique = 2
+    basal = 3
+    axon = 4
+
+
+
+
+def repair_type_map(neuron, apical_section):
+    extended_types = dict()
+    for section in iter_sections(neuron):
+        if section.type == SectionType.apical_dendrite:
+            extended_types[section] = RepairType.oblique
+        elif section.type == SectionType.basal_dendrite:
+            extended_types[section] = RepairType.basal
+        elif section.type == SectionType.axon:
+            extended_types[section] = RepairType.axon
+
+    if apical_section is not None:
+        for section in apical_section.ipreorder():
+            extended_types[section] = RepairType.tuft
+
+        # The value for the apical section must be overriden to 'trunk'
+        for section in apical_section.iupstream():
+            extended_types[section] = RepairType.trunk
+    return extended_types
 
 
 def unit_vector(vector):

--- a/neuror/utils.py
+++ b/neuror/utils.py
@@ -10,6 +10,7 @@ from morphio import SectionType
 
 L = logging.getLogger('neuror')
 
+
 class RepairType(Enum):
     '''The types used for the repair.
 
@@ -24,6 +25,7 @@ class RepairType(Enum):
 
 
 def repair_type_map(neuron, apical_section):
+    '''Return a dict of extended types'''
     extended_types = dict()
     for section in iter_sections(neuron):
         if section.type == SectionType.apical_dendrite:

--- a/neuror/utils.py
+++ b/neuror/utils.py
@@ -23,8 +23,6 @@ class RepairType(Enum):
     axon = 4
 
 
-
-
 def repair_type_map(neuron, apical_section):
     extended_types = dict()
     for section in iter_sections(neuron):

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'morph-tool>=0.1.14',
         'morphio>=2.1.1',
         'neurom>=2.0.0.dev0',
+        'numpy>=1.19.2',
         'nptyping>=1.3.0',
         'pandas>=0.24.2',
         'pyquaternion>=0.9.2',

--- a/tests/test_legacy_detection.py
+++ b/tests/test_legacy_detection.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
 from neurom import load_neuron
-from nose.tools import assert_raises
-from numpy.testing import (assert_array_almost_equal, assert_array_equal,
-                           assert_equal)
+from nose.tools import assert_raises, assert_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 from morph_tool.spatial import point_to_section_segment
 
 import neuror.cut_plane.legacy_detection as test_module
+from neuror.utils import repair_type_map
 
 DATA_PATH = Path(__file__).parent / 'data'
 
@@ -14,7 +14,7 @@ SIMPLE = load_neuron(DATA_PATH / 'simple.swc')
 
 
 def test_legacy():
-    points, sign = test_module.cut_detect(SIMPLE, 'y')
+    points, sign = test_module.internal_cut_detection(SIMPLE, 'y', offset=0)
     assert_array_equal(points,
                        [[ 6., -4., 0.],
                         [-5., -4., 0.]])
@@ -30,10 +30,10 @@ def test_legacy_compare_with_legacy_result():
     The arguments are the one used in the legacy morphology workflow.
     '''
     neuron = load_neuron(DATA_PATH / 'compare-bbpsdk/rp120430_P-2_idA.h5')
-    points, sign = test_module.cut_detect(neuron, 'z')
+    points, sign = test_module.internal_cut_detection(neuron, 'z', offset=0)
     assert_equal(sign, 1)
-    cut_sections = [point_to_section_segment(neuron, point)[0]
-                    for point in points]
+    cut_sections = {point_to_section_segment(neuron, point)[0]
+                    for point in points}
 
-    legacy_cut_sections = [13,14,17,18,38,39,40,45,58,67,68,69,73,75,76,93,94,101,102,103,105,106,109,110,111,120,124,125,148,149,150,156,157,158,162,163,164,166,167,168,169,192,202,203,205,206,208]
-    assert_array_equal(cut_sections, legacy_cut_sections)
+    legacy_cut_sections = {13,14,17,18,38,39,40,45,58,67,68,69,73,75,76,93,94,101,102,103,105,106,109,110,111,120,124,125,148,149,150,156,157,158,162,163,164,166,167,168,169,192,201,202,203,205,206,208}
+    assert_equal(cut_sections, legacy_cut_sections)

--- a/tests/test_legacy_detection.py
+++ b/tests/test_legacy_detection.py
@@ -4,6 +4,7 @@ from neurom import load_neuron
 from nose.tools import assert_raises, assert_equal
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 from morph_tool.spatial import point_to_section_segment
+from morph_tool import apical_point_section_segment
 
 import neuror.cut_plane.legacy_detection as test_module
 from neuror.utils import repair_type_map
@@ -12,15 +13,39 @@ DATA_PATH = Path(__file__).parent / 'data'
 
 SIMPLE = load_neuron(DATA_PATH / 'simple.swc')
 
+# OFFSET to go from BBPSDK section IDs to neurom ones
+OFFSET = 1
 
 def test_legacy():
-    points, sign = test_module.internal_cut_detection(SIMPLE, 'y', offset=0)
+    points, sign = test_module.internal_cut_detection(SIMPLE, 'y')
     assert_array_equal(points,
                        [[ 6., -4., 0.],
                         [-5., -4., 0.]])
     assert_equal(sign, -1)
 
     assert_raises(Exception, test_module.cut_detect, SIMPLE, 'z')
+
+def test_get_obliques():
+    '''Comparing results with the old repair launch with the following commands:
+
+    repair --dounravel 0 --inputdir /gpfs/bbp.cscs.ch/project/proj83/home/bcoste/release/out-new/01_ConvertMorphologies --input rp120430_P-2_idA --overlap=true --incremental=false --restrict=true --distmethod=mirror
+
+    The arguments are the one used in the legacy morphology workflow.
+    '''
+    neuron = load_neuron(DATA_PATH / 'compare-bbpsdk/rp120430_P-2_idA.h5')
+
+    apical_section = neuron.sections[apical_point_section_segment(neuron)[0]]
+    extended_types = repair_type_map(neuron, apical_section)
+    assert_equal([sec.id + OFFSET for sec in test_module.get_obliques(neuron, extended_types)],
+                 [217])
+
+
+def test_children_ids():
+    apical_section_id = 133
+    neuron = load_neuron(DATA_PATH / 'compare-bbpsdk/rp120430_P-2_idA.h5')
+    section = neuron.sections[apical_section_id]
+    assert_equal([sec.id + OFFSET for sec in test_module.children_ids(section)],
+                 [134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, ])
 
 def test_legacy_compare_with_legacy_result():
     '''Comparing results with the old repair launch with the following commands:
@@ -30,7 +55,7 @@ def test_legacy_compare_with_legacy_result():
     The arguments are the one used in the legacy morphology workflow.
     '''
     neuron = load_neuron(DATA_PATH / 'compare-bbpsdk/rp120430_P-2_idA.h5')
-    points, sign = test_module.internal_cut_detection(neuron, 'z', offset=0)
+    points, sign = test_module.internal_cut_detection(neuron, 'z')
     assert_equal(sign, 1)
     cut_sections = {point_to_section_segment(neuron, point)[0]
                     for point in points}

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -12,7 +12,8 @@ from nose.tools import assert_dict_equal, assert_equal, ok_
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 import neuror.main as test_module
-from neuror.main import Action, Repair, RepairType
+from neuror.main import Action, Repair
+from neuror.utils import RepairType
 
 DATA_PATH = Path(__file__).parent / 'data'
 

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -331,18 +331,19 @@ def test_repair_no_intact_axon():
 def test_legacy_compare_with_legacy_result():
     '''Comparing results with the old repair launch with the following commands:
 
-    repair --dounravel 0 --inputdir /gpfs/bbp.cscs.ch/project/proj83/home/bcoste/release/out-new/01_ConvertMorphologies --input rp120430_P-2_idA --overlap=true --incremental=false --restrict=true --distmethod=mirror
+    repair --dounravel 0 --inputdir /gpfs/bbp.cscs.ch/project/proj83/home/gevaert/morph-release/morph_release_old_code-2020-07-27/output/04_ZeroDiameterFix --input rp120430_P-2_idA --overlap=true --incremental=false --restrict=true --distmethod=mirror
 
     The arguments are the one used in the legacy morphology workflow.
     '''
     neuron = load_neuron(DATA_PATH / 'compare-bbpsdk/rp120430_P-2_idA.h5')
     obj = test_module.Repair(inputfile=DATA_PATH / 'compare-bbpsdk/rp120430_P-2_idA.h5', legacy_detection=True)
 
-    cut_sections = [point_to_section_segment(neuron, point)[0]
-                    for point in obj.cut_leaves]
+    cut_sections = {point_to_section_segment(neuron, point)[0]
+                    for point in obj.cut_leaves}
 
-    legacy_cut_sections = [13,14,17,18,38,39,40,45,58,67,68,69,73,75,76,93,94,101,102,103,105,106,109,110,111,120,124,125,148,149,150,156,157,158,162,163,164,166,167,168,169,192,202,203,205,206,208]
-    assert_array_equal(cut_sections, legacy_cut_sections)
+    legacy_cut_sections = {13,14,17,18,38,39,40,45,58,67,68,69,73,75,76,93,94,101,102,103,105,106,109,110,111,120,124,125,148,149,150,156,157,158,162,163,164,166,167,168,169,192,202,203,205,206,208}
+    legacy_cut_sections = {13,14,17,18,38,39,40,45,58,67,68,69,73,75,76,93,94,101,102,103,105,106,109,110,111,120,124,125,148,149,150,156,157,158,162,163,164,166,167,168,169,192,201,202,203,205,206,208}
+    assert_equal(cut_sections, legacy_cut_sections)
 
     obj._fill_repair_type_map()
 
@@ -382,9 +383,14 @@ def test_legacy_compare_with_legacy_result():
     assert_equal(actual_axons, expected_axons)
 
 
-    intacts = obj._find_intact_sub_trees()
-    assert_equal(list(filter(lambda sec: obj.repair_type_map[sec] == RepairType.trunk, intacts)),
+    intacts = defaultdict(list)
+
+    for sec in obj._find_intact_sub_trees():
+        intacts[obj.repair_type_map[sec]].append(sec)
+
+    assert_equal([sec.id + offset for sec in intacts[RepairType.trunk]],
                  [])
-    assert_equal(list(filter(lambda sec: obj.repair_type_map[sec] == RepairType.oblique, intacts)),
-                 [])
-    print({sec.type for sec in intacts})
+    assert_equal([sec.id + offset for sec in intacts[RepairType.oblique]],
+                 [217])
+    assert_equal({sec.id + offset for sec in intacts[RepairType.tuft]},
+                 {135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 151, 152, 153, 154, 155, 159, 160, 161, 165, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 193, 194, 195, 196, 197, 198, 199, 200, 204, 207, 209, 210, 211, 212, 213, 214, 215, 216})

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -341,7 +341,6 @@ def test_legacy_compare_with_legacy_result():
     cut_sections = {point_to_section_segment(neuron, point)[0]
                     for point in obj.cut_leaves}
 
-    legacy_cut_sections = {13,14,17,18,38,39,40,45,58,67,68,69,73,75,76,93,94,101,102,103,105,106,109,110,111,120,124,125,148,149,150,156,157,158,162,163,164,166,167,168,169,192,202,203,205,206,208}
     legacy_cut_sections = {13,14,17,18,38,39,40,45,58,67,68,69,73,75,76,93,94,101,102,103,105,106,109,110,111,120,124,125,148,149,150,156,157,158,162,163,164,166,167,168,169,192,201,202,203,205,206,208}
     assert_equal(cut_sections, legacy_cut_sections)
 

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -375,3 +375,16 @@ def test_legacy_compare_with_legacy_result():
     expected_tufts = {135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216}
     actual_tufts = {section.id + offset for section in types[RepairType.tuft]}
     assert_equal(actual_tufts, expected_tufts)
+
+
+    expected_axons = {1, 2, 77, 3, 70, 4, 59, 5, 46, 6, 41, 7, 40, 8, 39, 9, 38, 10, 19, 11, 16, 12, 15, 13, 14, 17, 18, 20, 37, 21, 34, 22, 31, 23, 28, 24, 27, 25, 26, 29, 30, 32, 33, 35, 36, 42, 45, 43, 44, 47, 58, 48, 53, 49, 52, 50, 51, 54, 55, 56, 57, 60, 69, 61, 66, 62, 63, 64, 65, 67, 68, 71, 76, 72, 75, 73, 74, 78, 83, 79, 82, 80, 81, 84, 85, 86, 89, 87, 88}
+    actual_axons = {section.id + offset for section in types[RepairType.axon]}
+    assert_equal(actual_axons, expected_axons)
+
+
+    intacts = obj._find_intact_sub_trees()
+    assert_equal(list(filter(lambda sec: obj.repair_type_map[sec] == RepairType.trunk, intacts)),
+                 [])
+    assert_equal(list(filter(lambda sec: obj.repair_type_map[sec] == RepairType.oblique, intacts)),
+                 [])
+    print({sec.type for sec in intacts})


### PR DESCRIPTION
In my first implementation of the legacy cut plane detection, I missed the fact that after 
`cut_detect` is run, it is not over at all since `cut_mark` is called on the apical children.
This should fix the legacy cut plane detection.