### PR TITLE
No longer check the cut plane probability

### DIFF
--- a/neuror/main.py
+++ b/neuror/main.py
@@ -300,11 +300,10 @@ class Repair(object):
             else:
                 plane = CutPlane.find(axon_donor)
             keep_axons_alive.append(plane)
-            no_cut_plane = (plane.minus_log_prob < 50)
             self.donated_intact_axon_sections.extend(
                 [section for section in iter_sections(plane.morphology)
                  if section.type == SectionType.axon and
-                 (no_cut_plane or is_branch_intact(section, plane.cut_leaves_coordinates))])
+                 is_branch_intact(section, plane.cut_leaves_coordinates)])
 
         self._fill_repair_type_map()
         self._fill_statistics_for_intact_subtrees()


### PR DESCRIPTION
When looking for the intact axons.

This was an enhancement with the new cut plane algorithm but
it is not compatible with the legacy cut plane on which we currently
focus. The old way of computing cut points does not allow for
computing the probability than the cut plane really exists.