### PR TITLE
Adds the ability to repair only certain type of neurites

### DIFF
--- a/neuror/main.py
+++ b/neuror/main.py
@@ -7,7 +7,7 @@ from collections import Counter, OrderedDict, defaultdict
 from enum import Enum
 from itertools import chain
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 from nptyping import NDArray
 
 import neurom as nm
@@ -238,12 +238,14 @@ def _max_y_dendritic_cylindrical_extent(neuron):
 class Repair(object):
     '''The repair class'''
 
+    # pylint: disable=dangerous-default-value
     def __init__(self,
                  inputfile: Path,
                  axons: Optional[Path] = None,
                  seed: Optional[int] = 0,
                  cut_leaves_coordinates: Optional[NDArray[(3, Any)]] = None,
-                 legacy_detection: bool = False):
+                 legacy_detection: bool = False,
+                 repair_flags: Dict[RepairType, bool] = {}):
         '''Repair the input morphology
 
         Args:
@@ -252,6 +254,8 @@ class Repair(object):
             seed: the numpy seed
             legacy_detection: if True, use the legacy cut plane detection
                 (see neuror.legacy_detection)
+            repair_flags: a dict of flags where key is a RepairType and value is whether
+                it should be repaired or not.
 
         Note: based on https://bbpcode.epfl.ch/browse/code/platform/BlueRepairSDK/tree/BlueRepairSDK/src/repair.cpp#n469  # noqa, pylint: disable=line-too-long
         '''
@@ -260,6 +264,16 @@ class Repair(object):
         self.inputfile = inputfile
         self.axon_donors = axons or list()
         self.donated_intact_axon_sections = list()
+
+        self.repair_flags = {
+            RepairType.basal: True,
+            RepairType.axon: True,
+            RepairType.tuft: True,
+            RepairType.oblique: True,
+        }
+
+        if repair_flags is not None:
+            self.repair_flags.update(repair_flags)
 
         if legacy_detection:
             self.cut_leaves = CutPlane.find_legacy(inputfile, 'z').cut_leaves_coordinates
@@ -281,7 +295,7 @@ class Repair(object):
         else:
             self.apical_section = None
 
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals, too-many-branches
     def run(self,
             outputfile: Path,
             plot_file: Optional[Path] = None):
@@ -329,6 +343,8 @@ class Repair(object):
 
         for section in sorted(cut_sections_in_bounding_cylinder, key=section_path_length):
             type_ = self.repair_type_map[section]
+            if not self.repair_flags[type_]:
+                continue
             L.info('Repairing: %s, section id: %s', type_, section.id)
             if type_ in {RepairType.basal, RepairType.oblique, RepairType.tuft}:
                 origin = self._get_origin(section)
@@ -606,13 +622,15 @@ class Repair(object):
         self.repair_type_map = repair_type_map(self.neuron, self.apical_section)
 
 
+# pylint: disable=dangerous-default-value
 def repair(inputfile: Path,
            outputfile: Path,
            axons: Optional[Path] = None,
            seed: int = 0,
            cut_leaves_coordinates: Optional[NDArray[(3, Any)]] = None,
            legacy_detection: bool = False,
-           plot_file: Optional[Path] = None):
+           plot_file: Optional[Path] = None,
+           repair_flags: Dict[RepairType, bool] = {}):
     '''The repair function
 
     Args:
@@ -621,6 +639,9 @@ def repair(inputfile: Path,
         axons: the axons
         seed: the numpy seed
         cut_leaves_coordinates: List of 3D coordinates from which to start the repair
+        plot_file: the filename of the plot
+        repair_flags: a dict of flags where key is a RepairType and value is whether
+            it should be repaired or not.
     '''
     ignored_warnings = (
         # We append the section at the wrong place and then we reposition them
@@ -640,7 +661,7 @@ def repair(inputfile: Path,
     if axons is None:
         axons = list()
     obj = Repair(inputfile, axons=axons, seed=seed, cut_leaves_coordinates=cut_leaves_coordinates,
-                 legacy_detection=legacy_detection)
+                 legacy_detection=legacy_detection, repair_flags=repair_flags)
     obj.run(outputfile, plot_file=plot_file)
 
     for warning in ignored_warnings:

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -323,6 +323,18 @@ def test_repair_axon():
                            neuron_out.section(40).points[0])
         ok_(len(neuron_out.section(40).points) > len(neuron_in.section(40).points))
 
+        # Test disactivating the axon repair
+        repair_flags = {RepairType.axon: False}
+        test_module.repair(filename, outfilename, axons=[filename], repair_flags=repair_flags)
+        neuron_out = load_neuron(outfilename)
+        axon = neuron_out.section(40)
+        ok_(axon.type == NeuriteType.axon)
+        assert_array_equal(neuron_in.section(40).points[0],
+                           neuron_out.section(40).points[0])
+
+        ok_(len(neuron_out.section(40).points) == len(neuron_in.section(40).points),
+            'The section should not have been regrown')
+
 
 def test_repair_no_intact_axon():
     filename = DATA_PATH / 'no-intact-basals.h5'


### PR DESCRIPTION
The repair function has a new "repair_flags" argument which is a dict of
RepairType -> bool that will disactivate the repair for each RepairType where the bool
is False.

This makes no scientific sense (why would you pick what needs to be repaired ?) but this is how it was implemented before.
https://bbpcode.epfl.ch/source/xref/platform/BlueRepairSDK/BlueRepairSDK/src/repair.cpp#488