### PR TITLE
Fix a bug causing duplicate points when grafting axons

### DIFF
--- a/neuror/axon.py
+++ b/neuror/axon.py
@@ -145,10 +145,16 @@ def repair(morphology, section, intact_sections, axon_branches, used_axon_branch
 
         L.info("Pasting axon branch with ID %s", branch.id)
 
+        end_point = section.points[-1, COLS.XYZ]
         appended = section.append_section(branch)
         translation = section.points[-1, COLS.XYZ] - appended.points[0, COLS.XYZ]
         align(appended, translation)
         translate(appended, translation)
+
+        # Make sure the child section first point is exactly the end point of the parent section
+        appended_points = np.copy(appended.points)
+        appended_points[0] = end_point
+        appended.points = appended_points
 
         if any(np.any(section.points[:, COLS.Y] > y_extent) for section in appended.iter()):
             L.info("Discarded, exceeds y-limit")


### PR DESCRIPTION
During the axon grafting, donor sections must be appended to existing sections.
They first, must be realigned and then translated so that they start exactly
at the end of the parent section.

Because of some floating point imprecision, sometimes the alignment (aka.
rotation) of the donor section, changes slightly (epsilon lever) the position of
the first point. Because of this the translation applied afterward does not
exactly position the donated section at the end of the parent section.

This offset creates some unwanted duplicate points when writing the morphology to disk.