### PR TITLE
error annotation cli

### DIFF
--- a/neuror/cli.py
+++ b/neuror/cli.py
@@ -46,6 +46,7 @@ def sanitize():
     more in the future.
     '''
 
+
 @cut_plane.group()
 def compute():
     '''CLI utilities to detect cut planes'''
@@ -69,7 +70,7 @@ def error_annotation():
 def file(input_file, output_file, error_summary_file):
     from neuror.error_annotation import annotate_single_morphology
 
-    if Path(input_file).suffix not in  ['.asc', '.ASC']:
+    if Path(input_file).suffix not in ['.asc', '.ASC']:
         raise Exception('Only .asc/.ASC files are allowed, please convert with morph-tool.')
 
     annotations, summary = annotate_single_morphology(input_file)
@@ -93,7 +94,7 @@ def folder(input_dir, output_dir, error_summary_file):
     morph_paths = iter_morphology_files(input_dir)
     annotations, summaries = annotate_morphologies(morph_paths)
     for morph_path, annotation in annotations.items():
-        output_file  = output_dir / Path(morph_path).name
+        output_file = output_dir / Path(morph_path).name
         shutil.copy(morph_path, output_file)
         with open(output_file, 'a') as morph_file:
             morph_file.write(annotations[morph_path])

--- a/neuror/cli.py
+++ b/neuror/cli.py
@@ -68,6 +68,7 @@ def error_annotation():
 @click.option('--error_summary_file', type=click.Path(file_okay=True), default='error_summary.json',
               help='Path to json file to save error summary')
 def file(input_file, output_file, error_summary_file):
+    '''Annotate errors on a morphology.'''
     from neuror.error_annotation import annotate_single_morphology
 
     if Path(input_file).suffix not in ['.asc', '.ASC']:
@@ -87,7 +88,7 @@ def file(input_file, output_file, error_summary_file):
 @click.option('--error_summary_file', type=click.Path(file_okay=True), default='error_summary.json',
               help='Path to json file to save error summary')
 def folder(input_dir, output_dir, error_summary_file):
-    from morph_tool.utils import iter_morphology_files
+    '''Annotate errors on a morphologies in a folder.'''
     from neuror.error_annotation import annotate_morphologies
 
     output_dir = Path(output_dir)
@@ -97,7 +98,7 @@ def folder(input_dir, output_dir, error_summary_file):
         output_file = output_dir / Path(morph_path).name
         shutil.copy(morph_path, output_file)
         with open(output_file, 'a') as morph_file:
-            morph_file.write(annotations[morph_path])
+            morph_file.write(annotation)
     with open(error_summary_file, 'w') as summary_file:
         json.dump(summaries, summary_file, indent=4)
 

--- a/neuror/cli.py
+++ b/neuror/cli.py
@@ -1,5 +1,6 @@
 '''The morph-tool command line launcher'''
 import json
+import shutil
 import logging
 import os
 from pathlib import Path
@@ -45,7 +46,6 @@ def sanitize():
     more in the future.
     '''
 
-
 @cut_plane.group()
 def compute():
     '''CLI utilities to detect cut planes'''
@@ -54,6 +54,51 @@ def compute():
 @cut_plane.group()
 def repair():
     '''CLI utilities to repair cut planes'''
+
+
+@cli.group()
+def error_annotation():
+    '''CLI utilities related to error annotations'''
+
+
+@error_annotation.command(short_help='Annotate errors on a morphology')
+@click.argument('input_file', type=click.Path(exists=True, file_okay=True))
+@click.argument('output_file')
+@click.option('--error_summary_file', type=click.Path(file_okay=True), default='error_summary.json',
+              help='Path to json file to save error summary')
+def file(input_file, output_file, error_summary_file):
+    from neuror.error_annotation import annotate_single_morphology
+
+    if Path(input_file).suffix not in  ['.asc', '.ASC']:
+        raise Exception('Only .asc/.ASC files are allowed, please convert with morph-tool.')
+
+    annotations, summary = annotate_single_morphology(input_file)
+    shutil.copy(input_file, output_file)
+    with open(output_file, 'a') as morph_file:
+        morph_file.write(annotations)
+    with open(error_summary_file, 'w') as summary_file:
+        json.dump(summary, summary_file)
+
+
+@error_annotation.command(short_help='Annotate errors on morphologies')
+@click.argument('input_dir')
+@click.argument('output_dir', type=click.Path(exists=True, file_okay=False, writable=True))
+@click.option('--error_summary_file', type=click.Path(file_okay=True), default='error_summary.json',
+              help='Path to json file to save error summary')
+def folder(input_dir, output_dir, error_summary_file):
+    from morph_tool.utils import iter_morphology_files
+    from neuror.error_annotation import annotate_morphologies
+
+    output_dir = Path(output_dir)
+    morph_paths = iter_morphology_files(input_dir)
+    annotations, summaries = annotate_morphologies(morph_paths)
+    for morph_path, annotation in annotations.items():
+        output_file  = output_dir / Path(morph_path).name
+        shutil.copy(morph_path, output_file)
+        with open(output_file, 'a') as morph_file:
+            morph_file.write(annotations[morph_path])
+    with open(error_summary_file, 'w') as summary_file:
+        json.dump(summaries, summary_file, indent=4)
 
 
 # pylint: disable=function-redefined

--- a/neuror/error_annotation.py
+++ b/neuror/error_annotation.py
@@ -1,3 +1,4 @@
+"""Annotation errors on morphologies."""
 from functools import partial
 import logging
 from neurom.check import neuron_checks as nc

--- a/neuror/error_annotation.py
+++ b/neuror/error_annotation.py
@@ -1,0 +1,58 @@
+from functools import partial
+import logging
+from neurom.check import neuron_checks as nc
+from neurom.apps.annotate import annotate
+from neurom import load_neuron
+
+L = logging.getLogger("neuror")
+
+CHECKERS = {
+    nc.has_no_fat_ends: {"name": "fat end", "label": "Circle3", "color": "Blue"},
+    partial(nc.has_no_jumps, axis="z"): {"name": "zjump", "label": "Circle2", "color": "Green"},
+    nc.has_no_narrow_start: {"name": "narrow start", "label": "Circle1", "color": "Blue"},
+    nc.has_no_dangling_branch: {"name": "dangling", "label": "Circle6", "color": "Magenta"},
+    nc.has_multifurcation: {"name": "Multifurcation", "label": "Circle8", "color": "Yellow"},
+}
+
+
+def annotate_single_morphology(morph_path):
+    """Annotate errors on a morphology.
+
+    Args:
+        morph_path (str): absolute path to an ascii morphology
+
+    Returns:
+        annotations to append to .asc file
+        dict of error summary
+    """
+    neuron = load_neuron(morph_path)
+    results = [checker(neuron) for checker in CHECKERS]
+    summary = {
+        setting["name"]: len(result.info)
+        for result, setting in zip(results, CHECKERS.values())
+        if result.info
+    }
+    return annotate(results, CHECKERS.values()), summary
+
+
+def annotate_morphologies(morph_paths):
+    """Annotate errors on a list of morphologies.
+
+    Args:
+        morph_paths (list): list of str of paths to morphologies.
+
+    Returns:
+        dict annotations to append to .asc file (morph_path as keys)
+        dict of dict of error summary (morph_path as keys)
+    """
+    summaries = {}
+    annotations = {}
+    for morph_path in morph_paths:
+        try:
+            annotations[str(morph_path)], summaries[str(morph_path)] = annotate_single_morphology(
+                morph_path
+            )
+        except Exception as e:  # noqa, pylint: disable=broad-except
+            L.warning("%s failed", morph_path)
+            L.warning(e, exc_info=True)
+    return annotations, summaries

--- a/neuror/sanitize.py
+++ b/neuror/sanitize.py
@@ -9,17 +9,13 @@ import numpy as np
 from morphio import MorphioError, SomaType, set_maximum_warnings
 from morphio.mut import Morphology  # pylint: disable=import-error
 from tqdm import tqdm
+from morph_tool.utils import iter_morphology_files
 
 L = logging.getLogger('neuror')
 
 
 class CorruptedMorphology(Exception):
     '''Exception for morphologies that should not be used'''
-
-
-def iter_morphologies(folder):
-    '''Recursively yield morphology files in folder and its sub-directories.'''
-    return (path for path in folder.rglob('*') if path.suffix.lower() in {'.swc', '.h5', '.asc'})
 
 
 def sanitize(input_neuron, output_path):
@@ -85,7 +81,7 @@ def sanitize_all(input_folder, output_folder, nprocesses=1):
     '''
     set_maximum_warnings(0)
 
-    morphologies = list(iter_morphologies(Path(input_folder)))
+    morphologies = iter_morphology_files(input_folder)
     func = partial(_sanitize_one, input_folder=input_folder, output_folder=output_folder)
     if nprocesses == 1:
         results = map(func, morphologies)

--- a/neuror/sanitize.py
+++ b/neuror/sanitize.py
@@ -4,6 +4,9 @@ from functools import partial
 from multiprocessing import Pool
 from pathlib import Path
 
+import numpy as np
+from tqdm import tqdm
+
 import morphio
 import numpy as np
 from morphio import MorphioError, SomaType, set_maximum_warnings
@@ -12,6 +15,11 @@ from tqdm import tqdm
 from morph_tool.utils import iter_morphology_files
 
 L = logging.getLogger('neuror')
+
+
+def iter_morphologies(folder):
+    '''Recursively yield morphology files in folder and its sub-directories.'''
+    return (path for path in folder.rglob('*') if path.suffix.lower() in {'.swc', '.h5', '.asc'})
 
 
 class CorruptedMorphology(Exception):
@@ -81,7 +89,7 @@ def sanitize_all(input_folder, output_folder, nprocesses=1):
     '''
     set_maximum_warnings(0)
 
-    morphologies = iter_morphology_files(input_folder)
+    morphologies = list(iter_morphologies(Path(input_folder)))
     func = partial(_sanitize_one, input_folder=input_folder, output_folder=output_folder)
     if nprocesses == 1:
         results = map(func, morphologies)

--- a/tests/data/neurite-with-multiple-types.swc
+++ b/tests/data/neurite-with-multiple-types.swc
@@ -1,0 +1,12 @@
+# simple.swc but the neurite type change along its way
+
+
+ 1 1  0  0 0 1. -1
+ 2 3  0  0 0 1.  1
+ 3 3  0  5 0 1.  2
+ 4 3 -5  5 0 1.5 3
+ 5 3  6  5 0 1.5 3
+ 6 2  0  0 0 1.  1
+ 7 2  0 -4 0 1.  6
+ 8 2  6 -4 0 2.  7
+ 9 3 -5 -4 0 2.  7  # Type went from 2 to 3

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,26 @@ from neuror.cli import cli
 DATA = Path(__file__).parent / 'data'
 
 
+def test_error_annotaiton_file():
+    runner = CliRunner()
+    with TemporaryDirectory('test-file') as folder:
+        result = runner.invoke(cli, ['error-annotation', 'file',
+                                     str(DATA / 'real.asc'),
+                                     str(Path(folder, 'out.asc'))])
+        assert_equal(result.exit_code, 0, result.exception)
+
+
+def test_error_annotation_folder():
+    runner = CliRunner()
+    with TemporaryDirectory('test-cli-folder') as folder:
+        result = runner.invoke(cli, ['error-annotation', 'folder',
+                                     str(DATA / 'input-repair-all'),
+                                     folder])
+        assert_equal(result.exit_code, 0, result.exception)
+        assert_equal(set(str(path.relative_to(folder)) for path in Path(folder).rglob('*')),
+                     {'simple.asc', 'simple2.asc'})
+
+
 def test_repair_file():
     runner = CliRunner()
     with TemporaryDirectory('test-file') as folder:


### PR DESCRIPTION
This  provides a CLi for the error annoation tool that is currently implemented in the internal morph-service web application. Being only based on NeuroM, the move is fairly trivial, and can know be used without web app easily.