### PR TITLE
`sanitize` also raises when a neurite has multiple neurite types

### DIFF
--- a/tests/data/neurite-with-multiple-types.swc
+++ b/tests/data/neurite-with-multiple-types.swc
@@ -1,0 +1,12 @@
+# simple.swc but the neurite type change along its way
+
+
+ 1 1  0  0 0 1. -1
+ 2 3  0  0 0 1.  1
+ 3 3  0  5 0 1.  2
+ 4 3 -5  5 0 1.5 3
+ 5 3  6  5 0 1.5 3
+ 6 2  0  0 0 1.  1
+ 7 2  0 -4 0 1.  6
+ 8 2  6 -4 0 2.  7
+ 9 3 -5 -4 0 2.  7  # Type went from 2 to 3


### PR DESCRIPTION
Sometimes a basal dendrites sprouts an axon. In the current state of things,
this is not supported by the circuit building so let's catch it as early as possible.