### PR TITLE
Improve repair

### DIFF
--- a/neuror/axon.py
+++ b/neuror/axon.py
@@ -132,7 +132,7 @@ def repair(morphology, section, intact_sections, axon_branches, used_axon_branch
     '''
 
     if not intact_sections:
-        L.info("No intact axon found. Not repairing!")
+        L.debug("No intact axon found. Not repairing!")
         return
 
     similar = _similar_section(intact_sections, section)
@@ -141,12 +141,12 @@ def repair(morphology, section, intact_sections, axon_branches, used_axon_branch
     strahler_orders = {intact_section: strahler_order(intact_section)
                        for intact_section in intact_sections + branch_pool}
 
-    L.info('Branch pool count: %s', len(branch_pool))
+    L.debug('Branch pool count: %s', len(branch_pool))
     for branch in branch_pool:
         if (branch in used_axon_branches or strahler_orders[similar] != strahler_orders[branch]):
             continue
 
-        L.info("Pasting axon branch with ID %s", branch.id)
+        L.debug("Pasting axon branch with ID %s", branch.id)
 
         end_point = section.points[-1, COLS.XYZ]
         appended = section.append_section(branch)
@@ -160,10 +160,10 @@ def repair(morphology, section, intact_sections, axon_branches, used_axon_branch
         appended.points = appended_points
 
         if any(np.any(section.points[:, COLS.Y] > y_extent) for section in appended.iter()):
-            L.info("Discarded, exceeds y-limit")
+            L.debug("Discarded, exceeds y-limit")
             morphology.delete_section(appended)
         else:
-            L.info('Section appended')
+            L.debug('Section appended')
             used_axon_branches.add(branch)
             return
 

--- a/neuror/cut_plane/cut_leaves.py
+++ b/neuror/cut_plane/cut_leaves.py
@@ -1,4 +1,4 @@
-"""dETECT CUT LEAVES WITH NEW ALGO."""
+"""Detect cut leaves with new algo."""
 from itertools import product
 import numpy as np
 from neurom.core.dataformat import COLS
@@ -83,7 +83,7 @@ def find_cut_leaves(
     # set the half space coef_d as furthest morphology point
     for half_space, (axis, side) in zip(half_spaces, product(searched_axes, searched_half_spaces)):
         half_space.coefs[3] = -side * np.min(
-            half_spaces.project_on_directed_normal(morph.points), axis=0
+            half_space.project_on_directed_normal(morph.points), axis=0
         )
 
     # find the cut leaves

--- a/neuror/main.py
+++ b/neuror/main.py
@@ -17,6 +17,7 @@ from morph_tool.spatial import point_to_section_segment
 from morphio import PointLevel, SectionType
 from neurom import NeuriteType, iter_neurites, iter_sections, load_neuron
 from neurom.core.dataformat import COLS
+from neurom.core import Section
 from neurom.features.sectionfunc import branch_order, section_path_length
 from nptyping import NDArray
 from scipy.spatial.distance import cdist
@@ -25,12 +26,16 @@ from neuror import axon
 from neuror.cut_plane import CutPlane
 from neuror.utils import RepairType, direction, repair_type_map, rotation_matrix, section_length
 
-SEG_LENGTH = 5.0
-SHOLL_LAYER_SIZE = 10
-BIFURCATION_BOOSTER = 0
-NOISE_CONTINUATION = 0.7
-SOMA_REPULSION = 0.7
-BIFURCATION_ANGLE = 0
+_PARAMS = {
+    'seg_length': 5.0,  # lenghts of new segments
+    'sholl_layer_size': 10,  # resoluion of the shll profile
+    'noise_continuation': 0.5,  # together with seg_length, this controls the tortuosity
+    'soma_repulsion': 0.2,  # if 0, previous section direction, if 1, radial direction
+    'bifurcation_angle': 20,  # noise amplitude in degree around mean bif angle on the cell
+    'path_length_ratio': 0.5,  # a smaller value will make a strornger taper rate
+    'children_diameter_ratio': 0.8,  # 1: child diam = parent diam, 0: child diam = tip diam
+    'tip_percentile': 25,  # percentile of tip radius distributions to use as tip radius
+}
 
 # Epsilon can not be to small otherwise leaves stored in json files
 # are not found in the NeuroM neuron
@@ -55,13 +60,12 @@ def is_cut_section(section, cut_points):
 
 def is_branch_intact(branch, cut_points):
     '''Does the branch have leaves belonging to the cut plane ?'''
-    return all(not is_cut_section(section, cut_points)
-               for section in branch.ipreorder())
+    return all(not is_cut_section(section, cut_points) for section in branch.ipreorder())
 
 
-def _get_sholl_layer(section, origin):
+def _get_sholl_layer(section, origin, sholl_layer_size):
     '''Returns this section sholl layer'''
-    return int(np.linalg.norm(section.points[-1, COLS.XYZ] - origin) / SHOLL_LAYER_SIZE)
+    return int(np.linalg.norm(section.points[-1, COLS.XYZ] - origin) / sholl_layer_size)
 
 
 def _get_sholl_proba(sholl_data, section_type, sholl_layer, pseudo_order):
@@ -112,22 +116,23 @@ def _get_sholl_proba(sholl_data, section_type, sholl_layer, pseudo_order):
                             (Action.CONTINUATION, 0),
                             (Action.TERMINATION, 1)])
 
-    boost_bifurcation = int(total_counts * BIFURCATION_BOOSTER)
-    action_counts[Action.BIFURCATION] += boost_bifurcation
-    total_counts += boost_bifurcation
     res = OrderedDict([tuple((action, action_counts[action] / float(total_counts))) for action in
                        sorted(action_counts.keys(), key=lambda t: t.value)])
     return res
 
 
-def _grow_until_sholl_sphere(section, origin, sholl_layer):
+def _grow_until_sholl_sphere(
+    section, origin, sholl_layer, params, taper, tip_radius, current_trunk_radius
+):
     '''Grow until reaching next sholl layer
 
     Note: based on https://bbpcode.epfl.ch/browse/code/platform/BlueRepairSDK/tree/BlueRepairSDK/src/helper_dendrite.cpp#n363  # noqa, pylint: disable=line-too-long
     '''
     backwards_sections = 0
-    while _get_sholl_layer(section, origin) == sholl_layer and backwards_sections < 4:
-        _continuation(section, origin)
+    while _get_sholl_layer(
+        section, origin, params['sholl_layer_size']
+    ) == sholl_layer and backwards_sections < 4:
+        _continuation(section, origin, params, taper(current_trunk_radius), tip_radius)
 
         # make sure we don't grow back the origin
         is_last_segment_toward_origin = np.dot(
@@ -145,27 +150,6 @@ def _last_segment_vector(section, normalized=False):
     if normalized:
         return vec / np.linalg.norm(vec)
     return vec
-
-
-def _get_similar_child_diameters(sections, original_section):
-    '''Find an existing section with a similar diameter and returns the diameters
-    of its children
-
-    If no similar section is found, returns twice the diameter of the last point
-
-    Note: based on https://bbpcode.epfl.ch/browse/code/platform/BlueRepairSDK/tree/BlueRepairSDK/src/helper_dendrite.cpp#n76  # noqa, pylint: disable=line-too-long
-    '''
-    threshold = 0.2
-    diameter = original_section.points[-1, COLS.R] * 2
-
-    for section in sections:
-        if section.children and abs(section.points[-1, COLS.R] * 2 - diameter) < threshold:
-            return [2 * section.children[0].points[0, COLS.R],
-                    2 * section.children[1].points[0, COLS.R]]
-
-    L.warning("Oh no, no similar diameter found!")
-    return [original_section.points[-1, COLS.R] * 2,
-            original_section.points[-1, COLS.R] * 2]
 
 
 def _branching_angles(section, order_offset=0):
@@ -189,7 +173,7 @@ def _branching_angles(section, order_offset=0):
     return res
 
 
-def _continuation(sec, origin):
+def _continuation(sec, origin, params, taper, tip_radius):
     '''Continue growing the section
 
     Note: based on https://bbpcode.epfl.ch/browse/code/platform/BlueRepairSDK/tree/BlueRepairSDK/src/helper_dendrite.cpp#n241  # noqa, pylint: disable=line-too-long
@@ -202,7 +186,8 @@ def _continuation(sec, origin):
     section_direction = _last_segment_vector(sec)
     section_direction /= np.linalg.norm(section_direction)
 
-    radial_direction = sec.points[0, COLS.XYZ] - origin
+    # better to use last section point, to get direction at the tip from where we grow
+    radial_direction = sec.points[-1, COLS.XYZ] - origin
     length = np.linalg.norm(radial_direction)
     if length > EPSILON:
         radial_direction /= length
@@ -214,15 +199,18 @@ def _continuation(sec, origin):
     # It is not drawing a point inside a sphere but a cube.
     # so the probability of drawing in direction of the corners is higher
     noise_direction = (2 * np.random.random(size=3) - 1)
+    noise_direction /= np.linalg.norm(noise_direction)
 
-    direction_ = section_direction + \
-        SOMA_REPULSION * radial_direction + \
-        NOISE_CONTINUATION * noise_direction
-
+    direction_ = (
+        section_direction
+        + params["soma_repulsion"] * radial_direction
+        + params["noise_continuation"] * noise_direction
+    )
     direction_ /= np.linalg.norm(direction_)
 
-    coord = sec.points[-1, COLS.XYZ] + direction_ * SEG_LENGTH
-    radius = np.mean(sec.points[:, COLS.R])
+    coord = sec.points[-1, COLS.XYZ] + direction_ * params["seg_length"]
+    # we apply tapering function + minimum diameter
+    radius = max(tip_radius, sec.points[-1, COLS.R] - taper)
     new_point = np.append(coord, radius)
     sec.points = np.vstack((sec.points, new_point))
 
@@ -243,15 +231,30 @@ def _max_y_dendritic_cylindrical_extent(neuron):
 class Repair(object):
     '''The repair class'''
 
-    def __init__(self,
+    def __init__(self,  # pylint: disable=too-many-arguments
                  inputfile: Path,
                  axons: Optional[Path] = None,
                  seed: Optional[int] = 0,
                  cut_leaves_coordinates: Optional[NDArray[(3, Any)]] = None,
                  legacy_detection: bool = False,
                  repair_flags: Optional[Dict[RepairType, bool]] = None,
-                 apical_point: NDArray[3, float] = None):
+                 apical_point: NDArray[3, float] = None,
+                 params: Dict = None):
         '''Repair the input morphology
+
+        The repair algorithm uses sholl analysis of intact branches to grow new branches from cut
+        leaves. The algorithm is fairly complex, but can be controled via a few parameters in the
+        params dictionary. By default, they are:
+        _PARAMS = {
+            'seg_length': 5.0,  # lenghts of new segments
+            'sholl_layer_size': 10,  # resoluion of the shll profile
+            'noise_continuation': 0.5,  # together with seg_length, this controls the tortuosity
+            'soma_repulsion': 0.2,  # if 0, previous section direction, if 1, radial direction
+            'bifurcation_angle': 20,  # noise amplitude in degree around mean bif angle on the cell
+            'path_length_ratio': 0.5,  # a smaller value will make a strornger taper rate
+            'children_diameter_ratio': 0.8,  # 1: child diam = parent diam, 0: child diam = tip diam
+            'tip_percentile': 25,  # percentile of tip radius distributions to use as tip radius
+        }
 
         Args:
             inputfile: the input neuron to repair
@@ -263,6 +266,8 @@ class Repair(object):
             repair_flags: a dict of flags where key is a RepairType and value is whether
                 it should be repaired or not. If not provided, all types will be repaired.
             apical_point: 3d vector for apical point, else, the automatic apical detection is used
+                if apical_point == -1, no automatic detection will be tried
+            params: repair internal parameters (see comments in code for details)
 
         Note: based on https://bbpcode.epfl.ch/browse/code/platform/BlueRepairSDK/tree/BlueRepairSDK/src/repair.cpp#n469  # noqa, pylint: disable=line-too-long
         '''
@@ -272,6 +277,7 @@ class Repair(object):
         self.axon_donors = axons or list()
         self.donated_intact_axon_sections = list()
         self.repair_flags = repair_flags or dict()
+        self.params = params if params is not None else _PARAMS
 
         if legacy_detection:
             self.cut_leaves = CutPlane.find_legacy(inputfile, 'z').cut_leaves_coordinates
@@ -287,15 +293,45 @@ class Repair(object):
                                 for section in self.neuron.iter())
 
         self.info = dict()
-        if apical_point:
-            # recall MorphIO ID = NeuroM ID - 1
-            apical_section_id = point_to_section_segment(self.neuron, apical_point)[0] - 1
-        else:
-            apical_section_id, _ = apical_point_section_segment(self.neuron)
+        apical_section_id = None
+        if apical_point != -1:
+            if apical_point:
+                # recall MorphIO ID = NeuroM ID - 1
+                apical_section_id = point_to_section_segment(self.neuron, apical_point)[0] - 1
+            else:
+                apical_section_id, _ = apical_point_section_segment(self.neuron)
+
         if apical_section_id:
             self.apical_section = self.neuron.sections[apical_section_id]
         else:
             self.apical_section = None
+
+        # record the tip radius as a lower bound for diameters with taper, excluding axons
+        # because they are treated separately, with thinner diameters
+        _diameters = [
+            np.mean(leaf.points[:, COLS.R])
+            for neurite in self.neuron.neurites
+            if neurite.type is not NeuriteType.axon
+            for leaf in iter_sections(neurite, iterator_type=Section.ileaf)
+        ]
+        self.tip_radius = (
+            np.percentile(_diameters, self.params["tip_percentile"]) if _diameters else None
+        )
+        self.current_trunk_radius = None
+
+        # estimate a global tapering rate of the morphology as a function of trunk radius,
+        # such that the tip radius is attained on average af max_path_length, defined as a fraction
+        # of the maximal path length via the parameter path_lengt_ratio. The smaller this parameter
+        # the faster the radii will convert to tip_radius.
+        # TODO: maybe we would need this per neurite_type
+        max_path_length = self.params["path_length_ratio"] * np.max(
+            nm.get("terminal_path_lengths_per_neurite", self.neuron)
+        )
+        self.taper = (
+            lambda trunk_radius: (trunk_radius - self.tip_radius)
+            * self.params["seg_length"]
+            / max_path_length
+        )
 
     # pylint: disable=too-many-locals, too-many-branches
     def run(self,
@@ -349,18 +385,22 @@ class Repair(object):
                 L.debug('Repair flag set to False for section type %s : --> Skipping repair.',
                         type_)
                 continue
-            L.info('Repairing: %s, section id: %s', type_, section.id)
+            L.debug('Repairing: %s, section id: %s', type_, section.id)
             if type_ in {RepairType.basal, RepairType.oblique, RepairType.tuft}:
+                self.current_trunk_radius = [
+                    sec.points[0, COLS.R] for sec in section.iupstream()
+                ][-1]
                 origin = self._get_origin(section)
                 if section.type == NeuriteType.basal_dendrite:
-                    _continuation(section, origin)
+                    _continuation(section, origin, self.params,
+                                  self.taper(self.current_trunk_radius), self.tip_radius)
                 self._grow(section, self._get_order_offset(section), origin)
             elif type_ == RepairType.axon:
                 axon.repair(self.neuron, section, intact_axonal_sections,
                             self.donated_intact_axon_sections, used_axon_branches,
                             self.max_y_extent)
             elif type_ == RepairType.trunk:
-                L.info('Trunk repair is not (nor has ever been) implemented')
+                L.debug('Trunk repair is not (nor has ever been) implemented')
             else:
                 raise Exception('Unknown type: {}'.format(type_))
 
@@ -372,7 +412,7 @@ class Repair(object):
                 L.warning('Skipping writing plots as [plotly] extra is not installed')
 
         self.neuron.write(outputfile)
-        L.info('Repair successful for %s', self.inputfile)
+        L.debug('Repair successful for %s', self.inputfile)
 
     def _find_intact_obliques(self):
         '''
@@ -402,7 +442,7 @@ class Repair(object):
                       is_branch_intact(neurite.root_node, self.cut_leaves))]
 
         if not basals:
-            L.warning("No intact basals found. Falling back on less strict selection.")
+            L.debug("No intact basals found. Falling back on less strict selection.")
             basals = [section for section in iter_sections(self.neuron)
                       if (section.type == NeuriteType.basal_dendrite and
                           not is_cut_section(section, self.cut_leaves))]
@@ -502,9 +542,10 @@ class Repair(object):
                 assert repair_type == self.repair_type_map[branch], \
                     'RepairType should not change along the branch way'
                 order = branch_order(section) - order_offset
-                first_layer, last_layer = (np.linalg.norm(
-                    section.points[[0, -1], COLS.XYZ] - origin, axis=1) // SHOLL_LAYER_SIZE).astype(
-                        int)
+                first_layer, last_layer = (
+                    np.linalg.norm(section.points[[0, -1], COLS.XYZ] - origin, axis=1)
+                    // self.params['sholl_layer_size']
+                ).astype(int)
                 per_type = data[repair_type]
 
                 starting_layer = min(first_layer, last_layer)
@@ -524,6 +565,7 @@ class Repair(object):
                     per_type[last_layer][order] = {Action.TERMINATION: 0,
                                                    Action.CONTINUATION: 0,
                                                    Action.BIFURCATION: 0}
+
                 per_type[last_layer][order][Action.BIFURCATION if section.children else
                                             Action.TERMINATION] += 1
         return data
@@ -534,18 +576,21 @@ class Repair(object):
         Note: based on https://bbpcode.epfl.ch/browse/code/platform/BlueRepairSDK/tree/BlueRepairSDK/src/helper_dendrite.cpp#n287  # noqa, pylint: disable=line-too-long
         '''
         current_diameter = section.points[-1, COLS.R] * 2
-        child_diameters = _get_similar_child_diameters(self.info['dendritic_sections'], section)
+
+        child_diameters = 2 * [self.params["children_diameter_ratio"] * current_diameter]
 
         median_angle = np.median(
-            self._best_case_angle_data(self.repair_type_map[section],
-                                       branch_order(section) - order_offset))
+            self._best_case_angle_data(
+                self.repair_type_map[section], branch_order(section) - order_offset
+            )
+        )
 
         last_segment_vec = _last_segment_vector(section)
         orthogonal = np.cross(last_segment_vec, section.points[-1, COLS.XYZ])
 
         def shuffle_direction(direction_):
             '''Return the direction to which to grow a child section'''
-            theta = median_angle + np.radians(np.random.random() * BIFURCATION_ANGLE)
+            theta = median_angle + np.radians(np.random.random() * self.params['bifurcation_angle'])
             first_rotation = np.dot(rotation_matrix(orthogonal, theta), direction_)
             new_dir = np.dot(rotation_matrix(direction_, np.random.random() * np.pi * 2),
                              first_rotation)
@@ -554,7 +599,8 @@ class Repair(object):
         for child_diameter in child_diameters:
             child_start = section.points[-1, COLS.XYZ]
             points = [child_start.tolist(),
-                      (child_start + shuffle_direction(last_segment_vec) * SEG_LENGTH).tolist()]
+                      (child_start + shuffle_direction(last_segment_vec) *
+                       self.params['seg_length']).tolist()]
             prop = PointLevel(points, [current_diameter, child_diameter])
 
             child = section.append_section(prop)
@@ -574,7 +620,7 @@ class Repair(object):
                 _y_cylindrical_extent(section) > self.max_y_cylindrical_extent):
             return
 
-        sholl_layer = _get_sholl_layer(section, origin)
+        sholl_layer = _get_sholl_layer(section, origin, self.params['sholl_layer_size'])
         pseudo_order = branch_order(section) - order_offset
         L.debug('In _grow. Layer: %s, order: %s', sholl_layer, pseudo_order)
 
@@ -587,16 +633,22 @@ class Repair(object):
         action = np.random.choice(list(proba.keys()), p=list(proba.values()))
 
         if action == Action.CONTINUATION:
-            L.info('Continuing')
-            backwards_sections = _grow_until_sholl_sphere(section, origin, sholl_layer)
+            L.debug('Continuing')
+            backwards_sections = _grow_until_sholl_sphere(section, origin, sholl_layer,
+                                                          self.params, self.taper,
+                                                          self.tip_radius,
+                                                          self.current_trunk_radius)
 
             if backwards_sections == 0:
                 self._grow(section, order_offset, origin)
             L.debug(section.points[-1])
 
         elif action == Action.BIFURCATION:
-            L.info('Bifurcating')
-            backwards_sections = _grow_until_sholl_sphere(section, origin, sholl_layer)
+            L.debug('Bifurcating')
+            backwards_sections = _grow_until_sholl_sphere(section, origin, sholl_layer,
+                                                          self.params, self.taper,
+                                                          self.tip_radius,
+                                                          self.current_trunk_radius)
             if backwards_sections == 0:
                 self._bifurcation(section, order_offset)
                 for child in section.children:
@@ -630,7 +682,8 @@ def repair(inputfile: Path,  # pylint: disable=too-many-arguments
            legacy_detection: bool = False,
            plot_file: Optional[Path] = None,
            repair_flags: Optional[Dict[RepairType, bool]] = None,
-           apical_point: List = None):
+           apical_point: List = None,
+           params: Dict = None):
     '''The repair function
 
     Args:
@@ -643,6 +696,7 @@ def repair(inputfile: Path,  # pylint: disable=too-many-arguments
         repair_flags: a dict of flags where key is a RepairType and value is whether
             it should be repaired or not. If not provided, all types will be repaired.
         apical_point: 3d vector for apical point, else, the automatic apical detection is used
+        params: repair internal parameters, None will use defaults
     '''
     ignored_warnings = (
         # We append the section at the wrong place and then we reposition them
@@ -653,7 +707,7 @@ def repair(inputfile: Path,  # pylint: disable=too-many-arguments
         morphio.Warning.only_child,
 
         # We are appending empty section and filling them later on
-        morphio.Warning.appending_empty_section
+        morphio.Warning.appending_empty_section,
     )
 
     for warning in ignored_warnings:
@@ -661,9 +715,13 @@ def repair(inputfile: Path,  # pylint: disable=too-many-arguments
 
     if axons is None:
         axons = list()
+
+    if params is None:
+        params = _PARAMS
+
     obj = Repair(inputfile, axons=axons, seed=seed, cut_leaves_coordinates=cut_leaves_coordinates,
                  legacy_detection=legacy_detection, repair_flags=repair_flags,
-                 apical_point=apical_point)
+                 apical_point=apical_point, params=params)
     obj.run(outputfile, plot_file=plot_file)
 
     for warning in ignored_warnings:

--- a/neuror/unravel.py
+++ b/neuror/unravel.py
@@ -30,7 +30,7 @@ def _get_principal_direction(points):
     X = np.copy(np.asarray(points))
     X -= np.mean(X, axis=0)
     C = np.dot(X.T, X)
-    w, v = np.linalg.eig(C)
+    w, v = np.linalg.eigh(C)
     return v[:, w.argmax()]
 
 
@@ -187,7 +187,7 @@ def unravel(filename, window_half_length=None,
             'z1': coord_after[:, 2],
         })
 
-    L.info('Unravel successful for file: %s', filename)
+    L.debug('Unravel successful for file: %s', filename)
     return new_morph, mapping
 
 
@@ -222,7 +222,7 @@ def unravel_all(raw_dir, unravelled_dir,
         os.mkdir(unravelled_planes_dir)
 
     for inputfilename in iter_morphology_files(raw_dir):
-        L.info('Unravelling: %s', inputfilename)
+        L.debug('Unravelling: %s', inputfilename)
         outfilename = Path(unravelled_dir, inputfilename.name)
         raw_plane = CutPlane.from_json(
             Path(raw_planes_dir, inputfilename.name).with_suffix('.json'))


### PR DESCRIPTION
Work PR to improve repair algorithm. Current modifications:

- better handling of diameters with global taper rates
- simplified handling of diameters at bifurcations
- improved soma_repulsion factor
- remove bifurcation boosting
- added parameters in a dict to access them upon execution
- move all logging to debug from warning (they are only useful for debug really, they just fill up the logs otherwise)