### PR TITLE
Add plotly extras to install

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,3 +20,4 @@ python:
       path: .
       extra_requirements:
           - docs
+          - plotly


### PR DESCRIPTION
Documentation building fails because the plotly extras are not installed.
```
home/docs/checkouts/readthedocs.org/user_builds/neuror/checkouts/stable/doc/source/api.rst:10: WARNING: autosummary: failed to import neuror.cut_plane.viewer.
Possible hints:
* AttributeError: module 'neuror.cut_plane' has no attribute 'viewer'
* ImportError: neuror[plotly] is not installed. Please install it by doing: pip install neuror[plotly]
* ImportError: 
```
Builds successfully with this change: https://readthedocs.org/projects/neuror/builds/17137174/